### PR TITLE
Adding helper function to format a table from a nested list

### DIFF
--- a/Text/PrettyPrint/Boxes.hs
+++ b/Text/PrettyPrint/Boxes.hs
@@ -38,6 +38,8 @@ module Text.PrettyPrint.Boxes
 
     , punctuateH, punctuateV
 
+    , formatTable
+
     -- * Alignment
 
     , Alignment
@@ -197,6 +199,26 @@ punctuateH a p bs = hcat a (intersperse p bs)
 -- | A vertical version of 'punctuateH'.
 punctuateV :: Alignment -> Box -> [Box] -> Box
 punctuateV a p bs = vcat a (intersperse p bs)
+
+--------------------------------------------------------------------------------
+-- Format table helper  --------------------------------------------------------
+--------------------------------------------------------------------------------
+
+-- | @formatTable als sep cols@ takes a list of alignments, and a uniform nested
+-- list of lists, such as [[\"Peter\", "1", "10.5"], [\"John\", "2", "3.2"]],
+-- and produces a formatted table, by applying the alignment to each column
+-- (the alignments are cycled, so if you only provide a single one, it will
+-- be automatically applied to all columns), separating the columns horizontally
+-- with @sep@ spaces. The result is a @Box@.
+formatTable :: [Alignment] -> Int -> [[String]] -> Box
+formatTable als sep cols = punctuateH top sep' $ map (uncurry singleCol) colal
+  where als' = cycle als
+        cols' = transpose cols
+        colal = zip als' cols'
+        sep' = emptyBox 0 sep
+
+singleCol :: Alignment -> [String] -> Box
+singleCol al = vcat al . map text
 
 --------------------------------------------------------------------------------
 --  Paragraph flowing  ---------------------------------------------------------


### PR DESCRIPTION
Being able to easily write a table with columns adjusted appropriately seems to be a common usecase for the library, see [this](http://www.tedreed.info/programming/2012/06/02/how-to-use-textprettyprintboxes/) example. This function makes it very easy. For example:

``` haskell
tbl = [["Stian", "1", "19.5"], ["Peter", "2", "21.55"], ["Alfred", "3", "99.1"]]
printBox $ formatTable [left, right, right] 2 tbl

Stian   1   19.5
Peter   2  21.55
Alfred  3   99.1
```

If you think including a function like this, I am very happy to polish it when it comes to which arguments it accepts, coding style etc. I personally think the lazy cycling of the align is neat, because it let's you supply just a single [left], and have that repeated for each column, but I don't know if it's good style.
