### PR TITLE
Hide Word for GHC 7.10

### DIFF
--- a/Text/PrettyPrint/Boxes.hs
+++ b/Text/PrettyPrint/Boxes.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.PrettyPrint.Boxes
@@ -66,6 +67,10 @@ module Text.PrettyPrint.Boxes
     , printBox
 
     ) where
+
+#if __GLASGOW_HASKELL__ > 708
+import Prelude hiding (Word)
+#endif
 
 import Data.String
 import Control.Arrow ((***), first)


### PR DESCRIPTION
`Word` is now exported by `Prelude`.