### PR TITLE
Update CHANGES, boxes.cabal

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,12 @@
+0.1.4: January 14, 2014
+  * Require Cabal >= 1.9.2
+  * Require CPP
+  * Only require OverloadedStrings for GHC
+  * Fix imports to work with 7.10.1
+  * Fix other imports to work with versions as far back as 7.0.1,
+    but only because it was easy this time
+  * Add testing framework skeletons for Cabal and Travis-CI.
+
 0.1.2: August 23, 2011
   * Export rows/cols.
 

--- a/boxes.cabal
+++ b/boxes.cabal
@@ -6,7 +6,7 @@ description:         A pretty-printing library for laying out text in
 category:            Text
 license:             BSD3
 license-file:        LICENSE
-extra-source-files:  CHANGES
+extra-source-files:  CHANGES, README.md
 author:              Brent Yorgey
 maintainer:          David Feuer <David.Feuer@gmail.com>
 build-type:          Simple
@@ -17,12 +17,18 @@ library
   build-depends:     base >= 3 && < 5, split >=0.2 && <0.3
   exposed-modules:   Text.PrettyPrint.Boxes
   extensions:        CPP
+  if impl(ghc)
+    extensions: OverloadedStrings
 
 Test-Suite test-boxes
-    type:            exitcode-stdio-1.0
-    main-is:         Text/PrettyPrint/Tests.hs
-    build-depends:   base >= 3 && < 5, split >=0.2 && <0.3, QuickCheck
-    cpp-options:     -DTESTING
+  type:              exitcode-stdio-1.0
+  main-is:           Text/PrettyPrint/Tests.hs
+  build-depends:     base >= 3 && < 5, split >=0.2 && <0.3, QuickCheck
+  extensions:        CPP
+  if impl(ghc)
+     extensions: OverloadedStrings
+  cpp-options:       -DTESTING
+-- Export some internals so the tests can get at them
 
 source-repository head
   type: git


### PR DESCRIPTION
Log changes for 0.1.4.

Let Cabal know that `OverloadedStrings` is required when the
implementation is GHC.