### PR TITLE
Clean up macros; remove unneeded extension

### DIFF
--- a/Text/PrettyPrint/Boxes.hs
+++ b/Text/PrettyPrint/Boxes.hs
@@ -1,24 +1,5 @@
 {-# LANGUAGE CPP #-}
-#ifndef MIN_VERSION_base
--- These are not precise, but allow the module to be built without cabal.
-#if __GLASGOW_HASKELL__ >= 709
-#define MIN_VERSION_base(major1,major2,minor) (((major1) <= 4) && ((major2) <= 8))
-#elif __GLASGOW_HASKELL__ >= 707
-#define MIN_VERSION_base(major1,major2,minor) (((major1) <= 4) && ((major2) <= 7))
-#elif __GLASGOW_HASKELL__ >= 706
-#define MIN_VERSION_base(major1,major2,minor) (((major1) <= 4) && ((major2) <= 6))
-#else
-#define MIN_VERSION_base(major1,major2,minor) 0
-#endif
-#endif
-
-#ifdef __GLASGOW_HASKELL__
-#define OVERLOADED_STRINGS 1
-#endif
-
-#ifdef OVERLOADED_STRINGS
-{-# LANGUAGE OverloadedStrings #-}
-#endif
+#include "boxes.h"
 
 -----------------------------------------------------------------------------
 -- |

--- a/boxes.cabal
+++ b/boxes.cabal
@@ -6,7 +6,8 @@ description:         A pretty-printing library for laying out text in
 category:            Text
 license:             BSD3
 license-file:        LICENSE
-extra-source-files:  CHANGES, README.md
+extra-source-files:  CHANGES, README.md, include/boxes.h
+
 author:              Brent Yorgey
 maintainer:          David Feuer <David.Feuer@gmail.com>
 build-type:          Simple
@@ -17,16 +18,14 @@ library
   build-depends:     base >= 3 && < 5, split >=0.2 && <0.3
   exposed-modules:   Text.PrettyPrint.Boxes
   extensions:        CPP
-  if impl(ghc)
-    extensions: OverloadedStrings
+  include-dirs:      include
 
 Test-Suite test-boxes
   type:              exitcode-stdio-1.0
   main-is:           Text/PrettyPrint/Tests.hs
   build-depends:     base >= 3 && < 5, split >=0.2 && <0.3, QuickCheck
   extensions:        CPP
-  if impl(ghc)
-     extensions: OverloadedStrings
+  include-dirs:      include
   cpp-options:       -DTESTING
 -- Export some internals so the tests can get at them
 

--- a/include/boxes.h
+++ b/include/boxes.h
@@ -1,0 +1,40 @@
+/*
+ * Common macros for boxes
+ */
+
+#ifndef HASKELL_BOXES_H
+#define HASKELL_BOXES_H
+
+#ifdef __GLASGOW_HASKELL__ 
+#define OVERLOADED_STRINGS 1 
+#endif
+
+/*
+ * We use cabal-generated MIN_VERSION_base to adapt to changes of base.
+ * Nevertheless, as a convenience, we also allow compiling without cabal by
+ * defining an approximate MIN_VERSION_base if needed. The alternative version
+ * guesses the version of base using the version of GHC. This is usually
+ * sufficiently accurate. However, it completely ignores minor version numbers,
+ * and it makes the assumption that a pre-release version of GHC will ship with
+ * base libraries with the same version numbers as the final release. This
+ * assumption is violated in certain stages of GHC development, but in practice
+ * this should very rarely matter, and will not affect any released version.
+ */
+#ifndef MIN_VERSION_base
+#if __GLASGOW_HASKELL__ >= 709
+#define MIN_VERSION_base(major1,major2,minor) (((major1)<4)||(((major1) == 4)&&((major2)<=8)))
+#elif __GLASGOW_HASKELL__ >= 707
+#define MIN_VERSION_base(major1,major2,minor) (((major1)<4)||(((major1) == 4)&&((major2)<=7)))
+#elif __GLASGOW_HASKELL__ >= 705
+#define MIN_VERSION_base(major1,major2,minor) (((major1)<4)||(((major1) == 4)&&((major2)<=6)))
+#elif __GLASGOW_HASKELL__ >= 703
+#define MIN_VERSION_base(major1,major2,minor) (((major1)<4)||(((major1) == 4)&&((major2)<=5)))
+#elif __GLASGOW_HASKELL__ >= 701
+#define MIN_VERSION_base(major1,major2,minor) (((major1)<4)||(((major1) == 4)&&((major2)<=4)))
+#elif __GLASGOW_HASKELL__ >= 700
+#define MIN_VERSION_base(major1,major2,minor) (((major1)<4)||(((major1) == 4)&&((major2)<=3)))
+#else
+#define MIN_VERSION_base(major1,major2,minor) (0)
+#endif
+#endif /* ifndef MIN_VERSION_base */
+#endif /* ifndef HASKELL_BOXES_H */


### PR DESCRIPTION
Move them to a separate file, and make the `MIN_VERSION_base`
fallback saner. Since boxes *supports* but does not *use*
`OverloadedStrings`, remove the `LANGUAGE` pragma for it, keeping
only the `IsString` instance declaration.