### PR TITLE
Sized QuickCheck properties to avoid blowup

### DIFF
--- a/Text/PrettyPrint/Tests.hs
+++ b/Text/PrettyPrint/Tests.hs
@@ -1,6 +1,9 @@
 import Test.QuickCheck
 import Text.PrettyPrint.Boxes
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative
+#endif
 import Control.Monad
 import System.Exit (exitFailure, exitSuccess)
 

--- a/Text/PrettyPrint/Tests.hs
+++ b/Text/PrettyPrint/Tests.hs
@@ -18,10 +18,10 @@ instance Arbitrary Box where
 -- generated Box is likely to be. This is necessary in order to avoid
 -- the tests getting stuck trying to generate ridiculously huge Box values.
 arbBox :: Int -> Gen Box
-arbBox n = do
-  NonNegative r <- arbitrary
-  NonNegative c <- arbitrary
-  liftM (Box r c) (arbContent n)
+arbBox n =
+  Box <$> nonnegative <*> nonnegative <*> arbContent n
+  where
+  nonnegative = getNonNegative <$> arbitrary
 
 instance Arbitrary Content where
   arbitrary = sized arbContent
@@ -34,13 +34,13 @@ instance Arbitrary Content where
 --
 -- See also section 3.2 of http://www.cs.tufts.edu/%7Enr/cs257/archive/john-hughes/quick.pdf
 arbContent :: Int -> Gen Content
-arbContent 0 = return Blank
+arbContent 0 = pure Blank
 arbContent n =
-  oneof [ return Blank
-        , liftM Text arbitrary
-        , liftM Row (halveSize (listOf box))
-        , liftM Col (halveSize (listOf box))
-        , liftM3 SubBox arbitrary arbitrary (halveSize box)
+  oneof [ pure Blank
+        , Text <$> arbitrary
+        , Row <$> halveSize (listOf box)
+        , Col <$> halveSize (listOf box)
+        , SubBox <$> arbitrary <*> arbitrary <*> halveSize box
         ]
   where
   halveSize = scale (`quot` 2)

--- a/Text/PrettyPrint/Tests.hs
+++ b/Text/PrettyPrint/Tests.hs
@@ -12,35 +12,53 @@ instance Arbitrary Alignment where
                        ]
 
 instance Arbitrary Box where
-  arbitrary = do
-    (NonNegative r) <- arbitrary
-    (NonNegative c) <- arbitrary
-    liftM (Box r c) arbitrary
+  arbitrary = sized arbBox
+
+-- A sized generator for boxes. The larger the parameter is, the larger a
+-- generated Box is likely to be. This is necessary in order to avoid
+-- the tests getting stuck trying to generate ridiculously huge Box values.
+arbBox :: Int -> Gen Box
+arbBox n = do
+  NonNegative r <- arbitrary
+  NonNegative c <- arbitrary
+  liftM (Box r c) (arbContent n)
 
 instance Arbitrary Content where
-  arbitrary = oneof [ return Blank
-                    , liftM Text arbitrary
-                    , liftM Row arbitrary
-                    , liftM Col arbitrary
-                    , liftM3 SubBox arbitrary arbitrary arbitrary
-                    ]
+  arbitrary = sized arbContent
+
+-- A sized generator for Content values. The larger the parameter is, the
+-- larger a generated Content is likely to be. This is necessary in order to
+-- avoid the tests getting stuck trying to generate ridiculously huge Content
+-- values. To this end, we halve the size parameter for child boxes or lists of
+-- child boxes.
+--
+-- See also section 3.2 of http://www.cs.tufts.edu/%7Enr/cs257/archive/john-hughes/quick.pdf
+arbContent :: Int -> Gen Content
+arbContent 0 = return Blank
+arbContent n =
+  oneof [ return Blank
+        , liftM Text arbitrary
+        , liftM Row (halveSize (listOf box))
+        , liftM Col (halveSize (listOf box))
+        , liftM3 SubBox arbitrary arbitrary (halveSize box)
+        ]
+  where
+  halveSize = scale (`quot` 2)
+  box = arbBox n
 
 -- extensional equivalence for Boxes
 b1 ==== b2 = render b1 == render b2
 
 prop_render_text s = render (text s) == (s ++ "\n")
 
-{-
-TODO: Find a way to enable these tests without time and space
-explosion.
+prop_empty_right_id b = b <> nullBox ==== b
+prop_empty_left_id b  = nullBox <> b ==== b
+prop_empty_top_id b   = nullBox // b ==== b
+prop_empty_bot_id b   = b // nullBox ==== b
 
---prop_empty_right_id b = b <> nullBox ==== b
---prop_empty_left_id b  = nullBox <> b ==== b
---prop_empty_top_id b   = nullBox // b ==== b
---prop_empty_bot_id b   = b // nullBox ==== b
--}
-
-main = quickCheckResult prop_render_text >>= \result ->
-          case result of
-            Success{} -> exitSuccess
-            _ -> exitFailure
+main = do
+  quickCheck prop_render_text
+  quickCheck prop_empty_right_id
+  quickCheck prop_empty_left_id
+  quickCheck prop_empty_top_id
+  quickCheck prop_empty_bot_id


### PR DESCRIPTION
Resolves #16. Here's a sample of what these generators produce (via `Test.QuickCheck.sample`):

```
Box {rows = 0, cols = 1, content = Blank}
Box {rows = 1, cols = 0, content = Text "\239"}
Box {rows = 4, cols = 0, content = SubBox AlignCenter2 AlignCenter1 (Box {rows = 1, cols = 2, content = SubBox AlignCenter1 AlignFirst (Box {rows = 1, cols = 0, content = Text "7"})})}
Box {rows = 3, cols = 1, content = Text ".0\189"}
Box {rows = 5, cols = 0, content = Text "HA\228ZQ"}
Box {rows = 9, cols = 7, content = Text "FV+yM"}
Box {rows = 12, cols = 4, content = SubBox AlignCenter1 AlignCenter2 (Box {rows = 3, cols = 2, content = Col [Box {rows = 0, cols = 0, content = SubBox AlignCenter1 AlignFirst (Box {rows = 1, cols = 0, content = Blank})}]})}
Box {rows = 0, cols = 7, content = Row [Box {rows = 5, cols = 5, content = Row [Box {rows = 2, cols = 0, content = Row [Box {rows = 1, cols = 0, content = SubBox AlignFirst AlignLast (Box {rows = 1, cols = 0, content = Row []})}]}]},Box {rows = 0, cols = 0, content = Blank},Box {rows = 3, cols = 1, content = Blank},Box {rows = 5, cols = 0, content = Text "+\ETX\153\ESC6"},Box {rows = 2, cols = 7, content = Col [Box {rows = 0, cols = 2, content = Row []},Box {rows = 0, cols = 1, content = Row []},Box {rows = 0, cols = 2, content = Row []}]},Box {rows = 6, cols = 4, content = Row [Box {rows = 0, cols = 3, content = SubBox AlignCenter2 AlignLast (Box {rows = 1, cols = 1, content = Row []})},Box {rows = 1, cols = 0, content = SubBox AlignCenter2 AlignLast (Box {rows = 1, cols = 0, content = Col []})}]},Box {rows = 3, cols = 6, content = Text "\150^@\238\DLE"}]}
Box {rows = 4, cols = 6, content = Text "v\SI\179\ETB"}
Box {rows = 8, cols = 4, content = Blank}
Box {rows = 0, cols = 0, content = SubBox AlignLast AlignCenter2 (Box {rows = 3, cols = 0, content = SubBox AlignFirst AlignCenter1 (Box {rows = 0, cols = 1, content = Text "m"})})}
```