### PR TITLE
Resolve #4: Add examples.

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20210108
+# version: 0.11.20210214
 #
-# REGENDATA ("0.11.20210108",["github","cabal.project"])
+# REGENDATA ("0.11.20210214",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -22,7 +22,7 @@ on:
       - master
 jobs:
   linux:
-    name: Haskell-CI Linux - GHC ${{ matrix.ghc }}
+    name: Haskell-CI - Linux - GHC ${{ matrix.ghc }}
     runs-on: ubuntu-18.04
     container:
       image: buildpack-deps:bionic
@@ -80,6 +80,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
+          echo "HEADHACKAGE=false" >> $GITHUB_ENV
           echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:
@@ -124,14 +125,27 @@ jobs:
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
+      - name: install cabal-docspec
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20210111/cabal-docspec-0.0.0.20210111.xz > cabal-docspec.xz
+          echo '0829bd034fba901cbcfe491d98ed8b28fd54f9cb5c91fa8e1ac62dc4413c9562  cabal-docspec.xz' | sha256sum -c -
+          xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
+          rm -f cabal-docspec.xz
+          chmod a+x $HOME/.cabal/bin/cabal-docspec
+          cabal-docspec --version
       - name: checkout
         uses: actions/checkout@v2
         with:
           path: source
+      - name: initial cabal.project for sdist
+        run: |
+          touch cabal.project
+          echo "packages: $GITHUB_WORKSPACE/source/." >> cabal.project
+          cat cabal.project
       - name: sdist
         run: |
           mkdir -p sdist
-          cd source || false
           $CABAL sdist all --output-dir $GITHUB_WORKSPACE/sdist
       - name: unpack
         run: |
@@ -174,6 +188,10 @@ jobs:
       - name: tests
         run: |
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
+      - name: docspec
+        run: |
+          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all
+          cabal-docspec $ARG_COMPILER
       - name: cabal check
         run: |
           cd ${PKGDIR_boxes} || false

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 0.2.0: ?, 2021
   * Change to use <> from Semigroup. Fixity is changed, but shouldn't affect things.
+    New fixities: `infixr 6 <>, <+>`; `infixr 4 //, /+/` (previously defaults `infixl 9`)
   * `text` accounts for newlines. Use (new) combinator `line` for single lines.
+  * `render` strips end-of-line whitespace
 
 0.1.5: March 10, 2018
   * Add support for GHC 8.4.1. Thanks, Andrés Sicard-Ramírez.

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,1 +1,2 @@
 branches: master
+docspec: True

--- a/test/Text/PrettyPrint/Tests.hs
+++ b/test/Text/PrettyPrint/Tests.hs
@@ -75,7 +75,7 @@ prop_sizes b = label (l (rows b * cols b)) True where
       | otherwise = "large"
 
 prop_render_text :: String -> Property
-prop_render_text s = trimEnds (render (text s)) === trimEnds s
+prop_render_text s = render (text s) === trimEnds s
 
 trimEnds :: String -> String
 trimEnds = unlines . map (dropWhileEnd isSpace) . lines
@@ -100,7 +100,7 @@ prop_associativity_vertical   a b c = a // (b // c) ==== (a // b) // c
 
 prop_issue38_text_nl_a :: Property
 prop_issue38_text_nl_a =
-    render (align center1 center1 5 5 $ text "x") === unlines
+    renderWithSpaces (align center1 center1 5 5 $ text "x") === unlines
     [ "     "
     , "     "
     , "  x  "
@@ -110,7 +110,7 @@ prop_issue38_text_nl_a =
 
 prop_issue38_text_nl_b :: Property
 prop_issue38_text_nl_b =
-    render (align center1 center1 5 5 $ text "x\ny") === unlines
+    renderWithSpaces (align center1 center1 5 5 $ text "x\ny") === unlines
     [ "     "
     , "     "
     , "  x  "
@@ -120,7 +120,7 @@ prop_issue38_text_nl_b =
 
 prop_issue38_text_nl_c :: Property
 prop_issue38_text_nl_c =
-    render (align center1 center1 5 5 $ line "x\ny") === unlines
+    renderWithSpaces (align center1 center1 5 5 $ line "x\ny") === unlines
     [ "     "
     , "     "
     , "  xy "


### PR DESCRIPTION
Also resolve #32 by making `render` trim eol whitespace.
`renderWithSpaces` added if someone needs old behaviour.

![Screenshot from 2021-02-20 00-44-07](https://user-images.githubusercontent.com/51087/108569661-f0b70b00-7314-11eb-9e1b-ffe9d657efa4.png)

(left and right are difficult for me)